### PR TITLE
docs: draft issues for remaining todo items

### DIFF
--- a/.github/issue-drafts/0001-resize-user-icons.md
+++ b/.github/issue-drafts/0001-resize-user-icons.md
@@ -1,0 +1,26 @@
+---
+title: Normalize size of user-provided launcher icons
+labels: enhancement, frontend
+---
+
+## Summary
+Ensure that SVG icons supplied by users for custom launcher entries are rendered at a
+consistent size so that logos do not appear cropped or stretched.
+
+## Background
+The existing TODO noted that JupyterLab already applies automatic resizing, but this
+cropping can truncate non-square icons. We should explicitly normalize the SVG viewBox
+and dimensions for user-supplied assets so each launcher button displays cleanly.
+
+## Proposed approach
+- Inspect how the launcher currently loads SVG content from settings.
+- Normalize incoming SVGs to a consistent square viewBox (e.g., 32x32) while preserving
+  aspect ratio.
+- Consider leveraging an SVG manipulation library to adjust width/height attributes or
+  wrap icons in a centered viewBox.
+- Add tests (or manual QA notes) to confirm that wide/tall icons render without cropping.
+
+## Acceptance criteria
+- [ ] User-supplied icons render at a consistent visual size without cropping.
+- [ ] Documented guidance for icon preparation is added to user-facing docs or settings.
+- [ ] Regression tests or manual QA steps confirm the new behavior.

--- a/.github/issue-drafts/0002-light-dark-icon-variants.md
+++ b/.github/issue-drafts/0002-light-dark-icon-variants.md
@@ -1,0 +1,25 @@
+---
+title: Support light and dark variants for custom launcher icons
+labels: enhancement, accessibility
+---
+
+## Summary
+Allow users to provide separate SVG assets that match JupyterLab's light and dark
+application themes so custom launcher icons remain legible in both modes.
+
+## Background
+Some icons rely on color contrasts that disappear when the UI theme changes. The
+previous TODO asked for a way to define light/dark variants alongside the existing
+single-icon option.
+
+## Proposed approach
+- Extend the launcher settings schema to accept `lightIcon` and `darkIcon` properties
+  (while maintaining backwards compatibility with the existing `icon` field).
+- Update the extension logic to choose the icon variant based on the current theme or
+  theme change events.
+- Provide migration guidance for users so existing configuration remains valid.
+
+## Acceptance criteria
+- [ ] Users can specify both light and dark icon variants in settings.
+- [ ] The launcher automatically swaps icons when the active theme changes.
+- [ ] Documentation covers how to provide dual-theme icons and any fallback behavior.

--- a/.github/issue-drafts/0003-launcher-ordering-controls.md
+++ b/.github/issue-drafts/0003-launcher-ordering-controls.md
@@ -1,0 +1,26 @@
+---
+title: Simplify launcher ordering controls in the settings editor
+labels: enhancement, UX
+---
+
+## Summary
+Clarify how users order launcher items in the settings editor by resolving the overlap
+between the "Move up/Move down" buttons and the numeric `rank` field.
+
+## Background
+The TODO highlighted that the existing controls are confusing: the rank ultimately
+controls ordering inside a category, yet the UI also shows move buttons. This can lead
+users to believe the buttons change order when they do not persist.
+
+## Proposed approach
+- Review how ranks are interpreted per category and how the settings array order is
+  applied.
+- Explore replacing the manual rank field with drag-and-drop or by relying solely on the
+  array order within each category.
+- If rank must remain, clarify its purpose with helper text and ensure the move buttons
+  reflect the actual persisted order.
+
+## Acceptance criteria
+- [ ] Launcher ordering controls behave predictably and match what is saved.
+- [ ] Updated UI copy or controls explain how ordering works.
+- [ ] Tests or manual QA cover ordering across multiple categories.

--- a/todo.md
+++ b/todo.md
@@ -1,9 +1,17 @@
 todo.md
 
+The remaining backlog items now live as draft GitHub issues so they can be promoted to
+real issues on the repository when ready. Use the linked files as the body for
+`gh issue create --title ... --body-file ...`.
+
+## Completed
+
 - [x] namespace css in svgs, right now they are in the global namespace of the dom and can overlap
-- [ ] resize all user added svg icons to a single size
-  - seems like jupyterlab already resizes svgs to fit w/i the launcher item. it crops them which is not ideal, but how many logos would we deal with that aren't square (fit within a square at least)
-- [ ] allow users to add light and dark variants of their svg icons
-- [ ] cleanup confusing ux between "move up", "move down" buttons in settings editor, and the rank field. rank is what actually impacts order w/i category. Maybe could remove rank and use order of settings array as ordering w/i the launcher. denoting between categories may be odd though.
 - [x] any new categories added should have a standard icon
   - try doing this with a "sentinel item", an item with rank -Infinity which is hidden if category is not already present
+
+## Migrated to GitHub issues
+
+- Resize all user added svg icons to a single size (`.github/issue-drafts/0001-resize-user-icons.md`)
+- Allow users to add light and dark variants of their svg icons (`.github/issue-drafts/0002-light-dark-icon-variants.md`)
+- Simplify launcher ordering controls in the settings editor (`.github/issue-drafts/0003-launcher-ordering-controls.md`)


### PR DESCRIPTION
## Summary
- replace the remaining TODO entries with references to GitHub issue drafts
- add three issue draft files under `.github/issue-drafts/` for the outstanding backlog

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68cefd428b4883338b322af75c7c344d